### PR TITLE
Add deprecation note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+Deprecated
+==========
+This tool has been deprecated. Please use the [espresso-runner](https://github.com/testobject/espresso-runner) tool instead.


### PR DESCRIPTION
With MRDC-292, this tool is being deprecated in favor of the
espresso-runner tool.